### PR TITLE
Deprecated ZSTD Functions on v1.5.7

### DIFF
--- a/zstdpp.hpp
+++ b/zstdpp.hpp
@@ -1,9 +1,42 @@
-#include <string.h>
-
+#include <vector>
+#include <cstdint>
+#include <string>
 #include "zstd.h"
 
-
 namespace zstdpp {
+
+using byte_t = std::uint8_t;
+using buffer_t = std::vector<byte_t>;
+
+inline buffer_t compress_buffer( buffer_t const& data, std::uint8_t compress_level = 3 ){
+    size_t est_compress_size = ZSTD_compressBound(data.size());
+    buffer_t comp_buffer{};
+    comp_buffer.resize(est_compress_size);
+    
+    auto compress_size =
+        ZSTD_compress((void*)comp_buffer.data(), est_compress_size, data.data(),
+                      data.size(), compress_level);
+        
+    comp_buffer.resize(compress_size);
+    comp_buffer.shrink_to_fit();
+    return comp_buffer;
+}
+
+inline buffer_t decompress_buffer(buffer_t data) {
+
+  auto const est_decomp_size =
+      ZSTD_getFrameContentSize(data.data(), data.size());
+
+  buffer_t decomp_buffer{};
+  decomp_buffer.resize(est_decomp_size);
+
+  size_t const decomp_size = ZSTD_decompress(
+      (void*)decomp_buffer.data(), est_decomp_size, data.data(), data.size());
+
+  decomp_buffer.resize(decomp_size);
+  decomp_buffer.shrink_to_fit();
+  return decomp_buffer;
+}
 
 inline std::string compress(const std::string data, int compress_level) {
 

--- a/zstdpp.hpp
+++ b/zstdpp.hpp
@@ -1,7 +1,9 @@
+#pragma once
+
+#include <string>
 #include <vector>
 #include <cstdint>
-#include <string>
-#include "zstd.h"
+#include <zstd.h>
 
 namespace zstdpp {
 
@@ -100,4 +102,5 @@ inline std::string& buff_decompress(const std::string& data,
   buffer.shrink_to_fit();
   return buffer;
 }
-}
+
+} // namespace zstdpp

--- a/zstdpp.hpp
+++ b/zstdpp.hpp
@@ -25,7 +25,7 @@ inline std::string compress(const std::string data, int compress_level) {
 inline std::string decompress(std::string data) {
 
   auto const est_decomp_size =
-      ZSTD_getDecompressedSize(data.data(), data.size());
+      ZSTD_getFrameContentSize(data.data(), data.size());
 
   std::string decomp_buffer{};
   decomp_buffer.resize(est_decomp_size);
@@ -56,7 +56,7 @@ inline std::string& buff_compress(const std::string data, std::string& buffer,
 inline std::string& buff_decompress(const std::string& data,
                                    std::string& buffer) {
   auto const est_decomp_size =
-      ZSTD_getDecompressedSize(data.data(), data.size());
+      ZSTD_getFrameContentSize(data.data(), data.size());
 
   buffer.resize(est_decomp_size);
 


### PR DESCRIPTION
Using ZSTD_getFrameContentSize instead ZSTD_getDecompressedSize (Deprecated API on zstd - v1.5.7)
Best Compression Ratio using ZSTD_getFrameContentSize in some cases.